### PR TITLE
Fix "iframe not found" errors

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -28,7 +28,7 @@ const IframeResizer = props => {
 
     iframeResize({ ...rest, onClose }, iframe)
 
-    return () => iframe.iframeResizer && iframe.iframeResizer.removeListeners()
+    return () => iframe.iFrameResizer && iframe.iFrameResizer.removeListeners()
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useImperativeHandle(forwardRef, () => ({


### PR DESCRIPTION
The cleanup on component unmount called `iframe.iframeResizer.removeListeners()`, while the correct thing to call is `iframe.iFrameResizer.removeListeners()`