### PR TITLE
forwardRef is missing in type declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,7 @@ declare module "iframe-resizer-react" {
       bodyMargin?: string | number | null;
       bodyPadding?: string | number | null;
       checkOrigin?: boolean | string[];
+      forwardRef?: any;
       inPageLinks?: boolean;
       enablePublicMethods?: boolean;
       heightCalculationMethod?:


### PR DESCRIPTION
Updating from 1.0.3 to 1.0.4 introduced an error when component is used in a TS context, due to the missing declaration of `forwardRef`.

I'm not sure about the type it can contain so I chose `any` for simplicity.