### PR TITLE
add method to imperative handle that exports iframe html element

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,10 @@ declare module "iframe-resizer-react" {
       iFrameResizer: IFrameObject;
     }
 
+    type IFrameForwardRef = Omit<IFrameObject, 'close' | 'removeListeners'> & {
+      getIframeElement: () => IFrameComponent;
+    }
+
     type IframeProps = React.DetailedHTMLProps<
       React.IframeHTMLAttributes<HTMLIFrameElement>,
       HTMLIFrameElement

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -31,6 +31,7 @@ const IframeResizer = (props) => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useImperativeHandle(forwardRef, () => ({
+    getIframeElement: () => iframeRef.current,
     resize: () => iframeRef.current.iFrameResizer.resize(),
     moveToAnchor: (anchor) =>
       iframeRef.current.iFrameResizer.moveToAnchor(anchor),


### PR DESCRIPTION
closes #42 

I think it is important to have the option to access the iframe element directly because this adds a lot more flexibility to the component.
This is just a simple way of accessing the iframe element from the outside without changing too much code and also without changing the signature of the component so this is currently fully backwards compatible.
There may be better ways to achieve this and I'm happy to discuss the changes.

Some further ideas:

One could use `React.forwardRef` but then the prop would be called `ref` instead of `forwardRef`. Still this may be more ideomatic.

If the iframe element is already accessible from outside the component, there is no real need anymore to proxy `resize`, `moveToAnchor` and `sendMessage`.
Therefore, one could even think about omitting `useImperativeHandle` alltogether and just setting the `forwardRef` on the iframe element directly. Still this also would not be backwards compatible.

Let me know what you think :)